### PR TITLE
Small change in BaseChatCommand.cs

### DIFF
--- a/ColonyAPI/ColonyAPI/Classes/BaseChatCommand.cs
+++ b/ColonyAPI/ColonyAPI/Classes/BaseChatCommand.cs
@@ -32,7 +32,13 @@ namespace ColonyAPI.Classes
                 }
                 BaseChatCommand newCommand;
                 if (ColonyAPI.Managers.ChatCommandManager.ChatCommandsList.TryGetValue(splits[0] + " " + splits[1], out newCommand))
-                    return newCommand.TryDoCommand(ply, chatItem);
+                {
+                    if (RunCommand(ply, splits, NetworkID.Invalid))
+                    {
+                        return newCommand.TryDoCommand(ply, chatItem);
+                    }
+                    else return true;
+                }
                 else
                 {
                     Chat.Send(ply, "Command " + splits[1] + " is not a part of " + splits[0]);


### PR DESCRIPTION
Master command must return true in Run Command in order to call the children command.

This allows master commands to check for permissions/config enabling before calling it's children. Decreasing copy paste code.